### PR TITLE
Add REST gateway and Next.js frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,31 @@ python -m sad_app.seed_cities.py
 python .\sad_app\server.py
 
 python -m sad_app.server
+
+## Gateway REST
+
+El repositorio incluye un gateway HTTP basado en FastAPI (`sad_app/rest_gateway.py`)
+que traduce peticiones REST al servicio gRPC. Para ejecutarlo:
+
+```bash
+export SAD_GRPC_TARGET=localhost:50051  # o la dirección donde corre el gRPC
+uvicorn sad_app.rest_gateway:app --host 0.0.0.0 --port 8000
+```
+
+La variable `SAD_REST_PORT` también puede usarse al ejecutar el módulo
+directamente (`python -m sad_app.rest_gateway`).
+
+## Frontend Next.js
+
+En `frontend/` se añadió una aplicación Next.js que consume el gateway REST y
+ofrece formularios para crear/consultar usuarios, autocompletar ciudades y
+gestionar deseos. Para levantarla en modo desarrollo:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+El frontend espera que la variable `NEXT_PUBLIC_API_BASE_URL` apunte al gateway
+REST (por defecto `http://localhost:8000`).

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ PY
 * `SAD_PORT`: puerto del servidor gRPC (por defecto `50051`).
 * `SAD_GRPC_TARGET`: dirección del servidor gRPC usada por el gateway REST (por defecto `localhost:50051`).
 * `SAD_REST_PORT`: puerto del gateway REST (por defecto `8000`).
+* `SAD_CORS_ORIGINS`: lista separada por comas con los orígenes permitidos para CORS (usa `*` por defecto para aceptar cualquiera).
 
 Puedes crear un archivo `.env` en la raíz con estas variables si lo prefieres.
 

--- a/README.md
+++ b/README.md
@@ -130,4 +130,10 @@ find . -name '__pycache__' -type d -prune -exec rm -rf {} +
 * `quick_test.py`: cliente gRPC de ejemplo para verificar el método `Ping` y
   el autocompletado de ciudades directamente contra el servidor gRPC.
 * `sad_app/seed_cities.py`: inicializa la colección de ciudades en MongoDB.
+
+## Solución de problemas
+
+* **`ModuleNotFoundError: No module named 'db'` al ejecutar `python -m sad_app.seed_cities`**: ejecuta el comando desde la raíz del repositorio y asegúrate de correrlo como módulo (incluyendo el prefijo `-m`). Esto habilita las importaciones relativas del paquete `sad_app`.
+
+* **`ModuleNotFoundError: No module named 'wishlist_pb2'` al iniciar `python -m sad_app.server`**: esto sucede si los stubs gRPC se regeneraron con la importación absoluta por defecto (`import wishlist_pb2`). Restaura la versión incluida en el repo (`git checkout -- sad_app/generated`) o verifica que las primeras líneas de `sad_app/generated/wishlist_pb2_grpc.py` usen `from . import wishlist_pb2 as wishlist__pb2`. Después vuelve a ejecutar el servidor.
 ```

--- a/README.md
+++ b/README.md
@@ -1,52 +1,133 @@
-pip install -r requirements.txt
+# Arquitectura Cliente-Servidor en Capas
 
-python -m grpc_tools.protoc -I SAD-proto/proto `
-  --python_out=sad_app\generated --grpc_python_out=sad_app\generated `
-  SAD-proto/proto/wishlist.proto
+Este proyecto implementa un servicio gRPC para administrar usuarios, deseos y
+sugerencias de ciudades. Además del backend gRPC, el repositorio incluye un
+**gateway REST** en FastAPI y un **frontend** en Next.js que se comunican con el
+servicio principal.
 
-New-Item -ItemType File sad_app\generated\__init__.py -Force | Out-Null
-Test-Path .\sad_app\generated\wishlist_pb2.py
+## Requisitos previos
 
-Test-Path .\sad_app\generated\wishlist_pb2_grpc.py
+* Python 3.10+
+* Node.js 18+ y npm
+* MongoDB 5+ (local o remoto)
+* `protoc` y `grpcio-tools` (se instalan con los requisitos de Python)
 
-New-Item -ItemType File .\sad_app\__init__.py -Force | Out-Null
+> 💡 Si no tienes MongoDB instalado localmente, puedes levantarlo con Docker:
+>
+> ```bash
+> docker run --name sad-mongo -p 27017:27017 -d mongo:6
+> ```
 
-New-Item -ItemType File .\sad_app\generated\__init__.py -Force | Out-Null
-
-Get-ChildItem -Recurse -Include __pycache__ | Remove-Item -Recurse -Force
-
-python .\sad_app\seed_cities.py
-
-python -m sad_app.seed_cities.py
-
-python .\sad_app\server.py
-
-python -m sad_app.server
-
-## Gateway REST
-
-El repositorio incluye un gateway HTTP basado en FastAPI (`sad_app/rest_gateway.py`)
-que traduce peticiones REST al servicio gRPC. Para ejecutarlo:
+## Preparación del entorno backend
 
 ```bash
-export SAD_GRPC_TARGET=localhost:50051  # o la dirección donde corre el gRPC
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Generar código gRPC (una sola vez o cuando cambie el proto)
+
+```bash
+python -m grpc_tools.protoc \
+  -I SAD-proto/proto \
+  --python_out=sad_app/generated \
+  --grpc_python_out=sad_app/generated \
+  SAD-proto/proto/wishlist.proto
+```
+
+Asegúrate de que existan los archivos `__init__.py` en los paquetes de Python:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+for path in [
+    Path('sad_app/__init__.py'),
+    Path('sad_app/generated/__init__.py')
+]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+PY
+```
+
+### Variables de entorno principales
+
+* `MONGO_URI`: cadena de conexión a MongoDB (por defecto `mongodb://localhost:27017`).
+* `MONGO_DB`: nombre de la base de datos (por defecto `sad_db`).
+* `SAD_PORT`: puerto del servidor gRPC (por defecto `50051`).
+* `SAD_GRPC_TARGET`: dirección del servidor gRPC usada por el gateway REST (por defecto `localhost:50051`).
+* `SAD_REST_PORT`: puerto del gateway REST (por defecto `8000`).
+
+Puedes crear un archivo `.env` en la raíz con estas variables si lo prefieres.
+
+### Inicializar datos de ciudades
+
+```bash
+python -m sad_app.seed_cities
+```
+
+### Ejecutar el servidor gRPC
+
+```bash
+python -m sad_app.server
+```
+
+El servidor quedará atendiendo en `localhost:50051` (o el valor de `SAD_PORT`).
+
+## Gateway REST (FastAPI)
+
+En otra terminal (con el entorno virtual activado), ejecuta:
+
+```bash
+export SAD_GRPC_TARGET=localhost:50051
 uvicorn sad_app.rest_gateway:app --host 0.0.0.0 --port 8000
 ```
 
-La variable `SAD_REST_PORT` también puede usarse al ejecutar el módulo
-directamente (`python -m sad_app.rest_gateway`).
+El gateway expondrá endpoints REST como `/users`, `/wishes`, `/cities/autocomplete`,
+traduciendo las peticiones al backend gRPC.
 
 ## Frontend Next.js
-
-En `frontend/` se añadió una aplicación Next.js que consume el gateway REST y
-ofrece formularios para crear/consultar usuarios, autocompletar ciudades y
-gestionar deseos. Para levantarla en modo desarrollo:
 
 ```bash
 cd frontend
 npm install
-npm run dev
+NEXT_PUBLIC_API_BASE_URL="http://localhost:8000" npm run dev
 ```
 
-El frontend espera que la variable `NEXT_PUBLIC_API_BASE_URL` apunte al gateway
-REST (por defecto `http://localhost:8000`).
+La aplicación quedará disponible en `http://localhost:3000` consumiendo el gateway REST.
+
+## Pruebas manuales desde la terminal
+
+Con el gateway REST en marcha, puedes ejecutar llamadas de ejemplo:
+
+```bash
+# Crear usuario
+curl -X POST http://localhost:8000/users \
+  -H 'Content-Type: application/json' \
+  -d '{"nombre":"Ana","apellido":"García","extra":{"rol":"tester"}}'
+
+# Autocompletar ciudades
+curl 'http://localhost:8000/cities/autocomplete?pais=CO&q=Bu&limit=5'
+
+# Crear deseo
+curl -X POST http://localhost:8000/wishes \
+  -H 'Content-Type: application/json' \
+  -d '{"user_id":"<ID_USUARIO>","titulo":"Viajar","descripcion":"Visitar feria","pais":"CO","ciudad":"Bucaramanga"}'
+```
+
+Reemplaza `<ID_USUARIO>` por el identificador devuelto al crear el usuario.
+
+## Limpieza de artefactos
+
+Si necesitas limpiar archivos compilados de Python:
+
+```bash
+find . -name '__pycache__' -type d -prune -exec rm -rf {} +
+```
+
+## Scripts útiles
+
+* `quick_test.py`: cliente gRPC de ejemplo para verificar el método `Ping` y
+  el autocompletado de ciudades directamente contra el servidor gRPC.
+* `sad_app/seed_cities.py`: inicializa la colección de ciudades en MongoDB.
+```

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,94 @@
+export type User = {
+  id: string;
+  nombre: string;
+  apellido: string;
+  extra: Record<string, string>;
+};
+
+export type Wish = {
+  id: string;
+  user_id: string;
+  titulo: string;
+  descripcion: string;
+  pais: string;
+  ciudad: string;
+  creado_en: number;
+};
+
+export type City = {
+  pais: string;
+  ciudad: string;
+};
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000";
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_BASE}${path}`, {
+    headers: { "Content-Type": "application/json", ...(init?.headers || {}) },
+    ...init,
+  });
+
+  if (!response.ok) {
+    const errorPayload = await response.json().catch(() => ({}));
+    const message =
+      (errorPayload?.detail as string | undefined) ??
+      `${response.status} ${response.statusText}`;
+    throw new Error(message);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function ping(): Promise<boolean> {
+  await request<{ ok: boolean }>("/health");
+  return true;
+}
+
+export async function createUser(payload: Omit<User, "id">): Promise<User> {
+  return request<User>("/users", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function getUser(userId: string): Promise<User> {
+  return request<User>(`/users/${userId}`);
+}
+
+export async function updateUser(
+  userId: string,
+  payload: Omit<User, "id">
+): Promise<User> {
+  return request<User>(`/users/${userId}`, {
+    method: "PUT",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function createWish(payload: Omit<Wish, "id" | "creado_en">) {
+  return request<Wish>("/wishes", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function listWishes(userId: string): Promise<Wish[]> {
+  return request<Wish[]>(`/users/${userId}/wishes`);
+}
+
+export async function autocompleteCity(
+  pais: string,
+  query: string,
+  limit = 5
+): Promise<City[]> {
+  const params = new URLSearchParams({ q: query, limit: String(limit) });
+  if (pais) {
+    params.append("pais", pais);
+  }
+  return request<City[]>(`/cities/autocomplete?${params.toString()}`);
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "sad-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "swr": "2.2.5"
+  },
+  "devDependencies": {
+    "@types/node": "20.10.5",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "eslint": "8.55.0",
+    "eslint-config-next": "14.1.0",
+    "typescript": "5.2.2"
+  }
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,0 +1,7 @@
+import type { AppProps } from "next/app";
+
+import "../styles/globals.css";
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,367 @@
+import { FormEvent, useMemo, useState } from "react";
+import useSWR from "swr";
+
+import {
+  autocompleteCity,
+  createUser,
+  createWish,
+  getUser,
+  listWishes,
+  ping,
+  updateUser,
+  type City,
+  type User,
+  type Wish,
+} from "../lib/api";
+
+const healthFetcher = async () => {
+  await ping();
+  return { ok: true };
+};
+
+function parseExtra(raw: string): Record<string, string> {
+  const extra: Record<string, string> = {};
+  raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .forEach((line) => {
+      const [key, ...rest] = line.split("=");
+      if (key && rest.length) {
+        extra[key.trim()] = rest.join("=").trim();
+      }
+    });
+  return extra;
+}
+
+function formatExtra(extra: Record<string, string>): string {
+  return Object.entries(extra)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("\n");
+}
+
+export default function HomePage() {
+  const { data: health, error: healthError, isLoading: healthLoading } = useSWR(
+    "health",
+    healthFetcher,
+    {
+      revalidateOnFocus: false,
+    }
+  );
+
+  const [createdUser, setCreatedUser] = useState<User | null>(null);
+  const [fetchedUser, setFetchedUser] = useState<User | null>(null);
+  const [userIdQuery, setUserIdQuery] = useState("");
+  const [updateUserId, setUpdateUserId] = useState("");
+  const [userExtraDraft, setUserExtraDraft] = useState("");
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [updateError, setUpdateError] = useState<string | null>(null);
+  const [lookupError, setLookupError] = useState<string | null>(null);
+
+  const [wishUserId, setWishUserId] = useState("");
+  const [wishTitle, setWishTitle] = useState("");
+  const [wishDescription, setWishDescription] = useState("");
+  const [wishCountry, setWishCountry] = useState("CO");
+  const [wishCity, setWishCity] = useState("");
+  const [wishError, setWishError] = useState<string | null>(null);
+  const [createdWish, setCreatedWish] = useState<Wish | null>(null);
+  const [wishes, setWishes] = useState<Wish[]>([]);
+
+  const [cityQuery, setCityQuery] = useState("Bu");
+  const [cityCountry, setCityCountry] = useState("CO");
+  const [cityResults, setCityResults] = useState<City[]>([]);
+  const [cityError, setCityError] = useState<string | null>(null);
+
+  const healthMessage = useMemo(() => {
+    if (healthLoading) {
+      return "Comprobando...";
+    }
+    if (healthError) {
+      return `Error: ${healthError.message}`;
+    }
+    if (health?.ok) {
+      return "Servicio gRPC disponible";
+    }
+    return "Sin verificar";
+  }, [health, healthError, healthLoading]);
+
+  const handleCreateUser = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+    setCreateError(null);
+    try {
+      const payload = {
+        nombre: String(form.get("nombre") || "").trim(),
+        apellido: String(form.get("apellido") || "").trim(),
+        extra: parseExtra(String(form.get("extra") || "")),
+      };
+      const user = await createUser(payload);
+      setCreatedUser(user);
+      setUserExtraDraft(formatExtra(user.extra));
+      setUpdateUserId(user.id);
+      setWishUserId(user.id);
+    } catch (error) {
+      setCreateError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  const handleGetUser = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLookupError(null);
+    try {
+      const user = await getUser(userIdQuery.trim());
+      setFetchedUser(user);
+    } catch (error) {
+      setFetchedUser(null);
+      setLookupError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  const handleUpdateUser = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setUpdateError(null);
+    try {
+      const form = new FormData(event.currentTarget);
+      const payload = {
+        nombre: String(form.get("nombre") || "").trim(),
+        apellido: String(form.get("apellido") || "").trim(),
+        extra: parseExtra(String(form.get("extra") || "")),
+      };
+      const user = await updateUser(updateUserId.trim(), payload);
+      setCreatedUser(user);
+      setUpdateUserId(user.id);
+      setUserExtraDraft(formatExtra(user.extra));
+    } catch (error) {
+      setUpdateError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  const handleCreateWish = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setWishError(null);
+    try {
+      const wish = await createWish({
+        user_id: wishUserId.trim(),
+        titulo: wishTitle.trim(),
+        descripcion: wishDescription.trim(),
+        pais: wishCountry.trim(),
+        ciudad: wishCity.trim(),
+      });
+      setCreatedWish(wish);
+    } catch (error) {
+      setCreatedWish(null);
+      setWishError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  const handleListWishes = async () => {
+    setWishError(null);
+    try {
+      const items = await listWishes(wishUserId.trim());
+      setWishes(items);
+    } catch (error) {
+      setWishError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  const handleAutocomplete = async () => {
+    setCityError(null);
+    try {
+      const items = await autocompleteCity(cityCountry.trim(), cityQuery.trim(), 5);
+      setCityResults(items);
+    } catch (error) {
+      setCityResults([]);
+      setCityError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  return (
+    <main>
+      <h1>SAD · Panel Cliente REST</h1>
+      <p>
+        Esta interfaz Next.js consume el gateway REST incluido en el repositorio
+        y permite interactuar con el backend gRPC sin salir del navegador.
+      </p>
+
+      <section>
+        <h2>1. Estado del servicio</h2>
+        <p>{healthMessage}</p>
+      </section>
+
+      <section>
+        <h2>2. Crear usuario</h2>
+        <form onSubmit={handleCreateUser} className="grid">
+          <label>
+            Nombre
+            <input name="nombre" placeholder="Sebastian" required />
+          </label>
+          <label>
+            Apellido
+            <input name="apellido" placeholder="Rodriguez" required />
+          </label>
+          <label>
+            Datos extra (formato clave=valor, uno por línea)
+            <textarea
+              name="extra"
+              placeholder="rol=tester\ntelegram=@seba"
+              rows={3}
+            />
+          </label>
+          <button type="submit">Crear usuario</button>
+        </form>
+        {createError && <p>Error: {createError}</p>}
+        {createdUser && (
+          <pre>{JSON.stringify(createdUser, null, 2)}</pre>
+        )}
+      </section>
+
+      <section>
+        <h2>3. Consultar usuario</h2>
+        <form onSubmit={handleGetUser} className="grid two">
+          <label>
+            ID de usuario
+            <input
+              value={userIdQuery}
+              onChange={(event) => setUserIdQuery(event.target.value)}
+              placeholder="uuid"
+              required
+            />
+          </label>
+          <button type="submit">Buscar</button>
+        </form>
+        {lookupError && <p>Error: {lookupError}</p>}
+        {fetchedUser && <pre>{JSON.stringify(fetchedUser, null, 2)}</pre>}
+      </section>
+
+      <section>
+        <h2>4. Actualizar usuario</h2>
+        <form onSubmit={handleUpdateUser} className="grid">
+          <label>
+            ID de usuario
+            <input
+              value={updateUserId}
+              onChange={(event) => setUpdateUserId(event.target.value)}
+              placeholder="uuid"
+              required
+            />
+          </label>
+          <label>
+            Nombre
+            <input name="nombre" placeholder="Sebastian" required />
+          </label>
+          <label>
+            Apellido
+            <input name="apellido" placeholder="Rodriguez" required />
+          </label>
+          <label>
+            Datos extra
+            <textarea
+              name="extra"
+              value={userExtraDraft}
+              onChange={(event) => setUserExtraDraft(event.target.value)}
+              rows={3}
+            />
+          </label>
+          <button type="submit">Guardar cambios</button>
+        </form>
+        {updateError && <p>Error: {updateError}</p>}
+      </section>
+
+      <section>
+        <h2>5. Autocompletar ciudades</h2>
+        <div className="grid two">
+          <label>
+            País (opcional)
+            <input
+              value={cityCountry}
+              onChange={(event) => setCityCountry(event.target.value)}
+              placeholder="CO"
+            />
+          </label>
+          <label>
+            Consulta
+            <input
+              value={cityQuery}
+              onChange={(event) => setCityQuery(event.target.value)}
+              placeholder="Bu"
+              required
+            />
+          </label>
+        </div>
+        <button onClick={handleAutocomplete}>Buscar ciudades</button>
+        {cityError && <p>Error: {cityError}</p>}
+        {cityResults.length > 0 && (
+          <ul>
+            {cityResults.map((city) => (
+              <li key={`${city.pais}-${city.ciudad}`}>
+                {city.pais} · {city.ciudad}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <h2>6. Crear y listar deseos</h2>
+        <form onSubmit={handleCreateWish} className="grid">
+          <label>
+            ID de usuario
+            <input
+              value={wishUserId}
+              onChange={(event) => setWishUserId(event.target.value)}
+              placeholder="uuid"
+              required
+            />
+          </label>
+          <label>
+            Título
+            <input
+              value={wishTitle}
+              onChange={(event) => setWishTitle(event.target.value)}
+              placeholder="Viajar a la Feria"
+              required
+            />
+          </label>
+          <label>
+            Descripción
+            <textarea
+              value={wishDescription}
+              onChange={(event) => setWishDescription(event.target.value)}
+              placeholder="Feria de las Flores"
+              rows={3}
+            />
+          </label>
+          <label>
+            País
+            <input
+              value={wishCountry}
+              onChange={(event) => setWishCountry(event.target.value)}
+              placeholder="CO"
+              required
+            />
+          </label>
+          <label>
+            Ciudad
+            <input
+              value={wishCity}
+              onChange={(event) => setWishCity(event.target.value)}
+              placeholder="Bucaramanga"
+              required
+            />
+          </label>
+          <button type="submit">Crear deseo</button>
+        </form>
+        <button onClick={handleListWishes} style={{ marginTop: "1rem" }}>
+          Listar deseos del usuario
+        </button>
+        {wishError && <p>Error: {wishError}</p>}
+        {createdWish && <pre>{JSON.stringify(createdWish, null, 2)}</pre>}
+        {wishes.length > 0 && <pre>{JSON.stringify(wishes, null, 2)}</pre>}
+      </section>
+
+      <footer style={{ textAlign: "center", opacity: 0.7 }}>
+        Gateway REST configurable mediante NEXT_PUBLIC_API_BASE_URL
+      </footer>
+    </main>
+  );
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,87 @@
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+a {
+  color: #38bdf8;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+section {
+  border: 1px solid #1e293b;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  background: #111c3a;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.45);
+}
+
+h1, h2 {
+  margin-top: 0;
+}
+
+label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #334155;
+  background: #0f172a;
+  color: inherit;
+}
+
+button {
+  padding: 0.55rem 1.25rem;
+  border-radius: 8px;
+  border: none;
+  background: #38bdf8;
+  color: #0f172a;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+pre {
+  background: #0b1220;
+  border-radius: 8px;
+  padding: 1rem;
+  overflow-x: auto;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.grid.two {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": "."
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ motor
 pydantic
 python-dotenv
 uvloop; sys_platform != "win32"
+fastapi
+uvicorn[standard]

--- a/sad_app/rest_gateway.py
+++ b/sad_app/rest_gateway.py
@@ -13,6 +13,7 @@ from typing import Dict, List, Optional
 
 import grpc
 from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
@@ -31,6 +32,21 @@ app = FastAPI(
         "deseos y autocompletado de ciudades."
     ),
     version="1.0.0",
+)
+
+
+def _parse_origins(value: str) -> List[str]:
+    if value.strip() == "*":
+        return ["*"]
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_parse_origins(os.getenv("SAD_CORS_ORIGINS", "*")),
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 

--- a/sad_app/rest_gateway.py
+++ b/sad_app/rest_gateway.py
@@ -1,0 +1,203 @@
+"""REST gateway that proxies HTTP requests to the gRPC DataAdminService.
+
+The module exposes a FastAPI application that keeps a single gRPC channel
+open for all incoming HTTP requests.  This allows any REST client –
+including the new Next.js frontend – to keep talking HTTP+JSON while the
+core of the system remains implemented in gRPC.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Optional
+
+import grpc
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from sad_app.generated import wishlist_pb2 as pb
+from sad_app.generated import wishlist_pb2_grpc as pb_grpc
+
+
+GRPC_TARGET = os.getenv("SAD_GRPC_TARGET", "localhost:50051")
+
+
+app = FastAPI(
+    title="SAD REST Gateway",
+    description=(
+        "Adaptador HTTP que consume el servicio gRPC DataAdminService. "
+        "Permite a clientes REST interactuar con las operaciones de usuarios, "
+        "deseos y autocompletado de ciudades."
+    ),
+    version="1.0.0",
+)
+
+
+class UserPayload(BaseModel):
+    nombre: str
+    apellido: str
+    extra: Dict[str, str] = Field(default_factory=dict)
+
+
+class UserResponseModel(UserPayload):
+    id: str
+
+
+class WishPayload(BaseModel):
+    user_id: str
+    titulo: str
+    descripcion: Optional[str] = ""
+    pais: str
+    ciudad: str
+
+
+class WishResponseModel(WishPayload):
+    id: str
+    creado_en: int
+
+
+class CityResponseModel(BaseModel):
+    pais: str
+    ciudad: str
+
+
+def _grpc_to_http_status(code: grpc.StatusCode) -> int:
+    mapping = {
+        grpc.StatusCode.INVALID_ARGUMENT: 400,
+        grpc.StatusCode.NOT_FOUND: 404,
+        grpc.StatusCode.UNAVAILABLE: 503,
+        grpc.StatusCode.ALREADY_EXISTS: 409,
+        grpc.StatusCode.PERMISSION_DENIED: 403,
+        grpc.StatusCode.UNAUTHENTICATED: 401,
+    }
+    return mapping.get(code, 500)
+
+
+def _pb_user_to_dict(user: pb.User) -> Dict[str, object]:
+    return {
+        "id": user.id,
+        "nombre": user.nombre,
+        "apellido": user.apellido,
+        "extra": dict(user.extra),
+    }
+
+
+def _pb_wish_to_dict(wish: pb.Wish) -> Dict[str, object]:
+    return {
+        "id": wish.id,
+        "user_id": wish.user_id,
+        "titulo": wish.titulo,
+        "descripcion": wish.descripcion,
+        "pais": wish.pais,
+        "ciudad": wish.ciudad,
+        "creado_en": wish.creado_en,
+    }
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    app.state.channel = grpc.aio.insecure_channel(GRPC_TARGET)
+    app.state.stub = pb_grpc.DataAdminServiceStub(app.state.channel)
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    await app.state.channel.close()
+
+
+async def _call_grpc(method, request):
+    try:
+        return await method(request)
+    except grpc.aio.AioRpcError as exc:  # pragma: no cover - network errors
+        detail = exc.details() or exc.code().name
+        raise HTTPException(
+            status_code=_grpc_to_http_status(exc.code()), detail=detail
+        ) from exc
+
+
+@app.get("/health")
+async def health() -> JSONResponse:
+    await _call_grpc(app.state.stub.Ping, pb.Empty())
+    return JSONResponse({"ok": True})
+
+
+@app.post("/users", response_model=UserResponseModel)
+async def create_user(payload: UserPayload) -> UserResponseModel:
+    response = await _call_grpc(
+        app.state.stub.CreateUser,
+        pb.CreateUserRequest(
+            nombre=payload.nombre, apellido=payload.apellido, extra=payload.extra
+        ),
+    )
+    return UserResponseModel(**_pb_user_to_dict(response.user))
+
+
+@app.get("/users/{user_id}", response_model=UserResponseModel)
+async def get_user(user_id: str) -> UserResponseModel:
+    response = await _call_grpc(
+        app.state.stub.GetUser, pb.GetUserRequest(id=user_id)
+    )
+    return UserResponseModel(**_pb_user_to_dict(response.user))
+
+
+@app.put("/users/{user_id}", response_model=UserResponseModel)
+async def update_user(user_id: str, payload: UserPayload) -> UserResponseModel:
+    response = await _call_grpc(
+        app.state.stub.UpsertUser,
+        pb.UpsertUserRequest(
+            id=user_id,
+            nombre=payload.nombre,
+            apellido=payload.apellido,
+            extra=payload.extra,
+        ),
+    )
+    return UserResponseModel(**_pb_user_to_dict(response.user))
+
+
+@app.post("/wishes", response_model=WishResponseModel)
+async def create_wish(payload: WishPayload) -> WishResponseModel:
+    response = await _call_grpc(
+        app.state.stub.CreateWish,
+        pb.CreateWishRequest(
+            user_id=payload.user_id,
+            titulo=payload.titulo,
+            descripcion=payload.descripcion,
+            pais=payload.pais,
+            ciudad=payload.ciudad,
+        ),
+    )
+    return WishResponseModel(**_pb_wish_to_dict(response.wish))
+
+
+@app.get("/users/{user_id}/wishes", response_model=List[WishResponseModel])
+async def list_wishes(user_id: str) -> List[WishResponseModel]:
+    response = await _call_grpc(
+        app.state.stub.ListWishesByUser,
+        pb.ListWishesByUserRequest(user_id=user_id),
+    )
+    return [WishResponseModel(**_pb_wish_to_dict(item)) for item in response.items]
+
+
+@app.get("/cities/autocomplete", response_model=List[CityResponseModel])
+async def autocomplete_cities(
+    q: str = Query(..., alias="q"),
+    pais: Optional[str] = None,
+    limit: int = Query(10, ge=1, le=25),
+) -> List[CityResponseModel]:
+    response = await _call_grpc(
+        app.state.stub.AutocompleteCity,
+        pb.AutocompleteCityRequest(pais=pais or "", query=q, limit=limit),
+    )
+    return [CityResponseModel(pais=item.pais, ciudad=item.ciudad) for item in response.items]
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    import uvicorn
+
+    uvicorn.run(
+        "sad_app.rest_gateway:app",
+        host="0.0.0.0",
+        port=int(os.getenv("SAD_REST_PORT", "8000")),
+        reload=bool(os.getenv("SAD_REST_RELOAD")),
+    )

--- a/sad_app/seed_cities.py
+++ b/sad_app/seed_cities.py
@@ -1,5 +1,6 @@
 import asyncio
-from db import get_db
+
+from .db import get_db
 
 data = [
     {"pais": "CO", "ciudad": "Bogotá"},


### PR DESCRIPTION
## Summary
- add a FastAPI-based REST gateway that adapts HTTP requests to the existing gRPC service
- scaffold a Next.js frontend that consumes the REST endpoints to manage users, wishes, and city autocomplete
- document how to run the new services and include required dependencies

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2ff400168832aa1965f62dfe1f039